### PR TITLE
Bump Node.js to v16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: "16.x"
       - run: yarn install
       - run: yarn test
       - run: yarn format-check

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: A GitHub token.
     required: true
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: wind


### PR DESCRIPTION
@rogerluan Thanks for this tool. My team uses it in a bunch of repos. Recently we started getting this warning from GitHub Actions about this particular action: `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16...`. I have this small change to bump the version of Node.js from 12 to 16. 

Would you please take a look at these changes and merge/release if things look ok?